### PR TITLE
CS-676 Ping engineers on RC cut

### DIFF
--- a/lib/lita/handlers/github_pinger.rb
+++ b/lib/lita/handlers/github_pinger.rb
@@ -95,6 +95,8 @@ module Lita
       end
 
       def act_on_release_comment(body, response)
+        return unless body['comment']['body']&.include?('@')
+
         comment = body['comment']['body']
         engineers_to_ping = []
         if comment.include?("@")


### PR DESCRIPTION
Adds ability automatically ping engineer on RC cut. We rely on slack and github handles to be present in 

https://github.com/snapdocs/snapbot/blob/master/lita_config.rb